### PR TITLE
Use tqdm.auto progressbar in xo.optimize

### DIFF
--- a/src/exoplanet/utils.py
+++ b/src/exoplanet/utils.py
@@ -214,7 +214,7 @@ def optimize(
 
     if verbose:
         if has_progress_bar:
-            has_progress_bar.close()
+            progress_bar.close()
 
         sys.stderr.write("message: {0}\n".format(info.message))
         sys.stderr.write("logp: {0} -> {1}\n".format(-initial, -info.fun))


### PR DESCRIPTION
This allows passing in a progress bar instance, disabling the progress bar, or (by default) using `tqdm.auto.tqdm` (as described in #85). 