### PR TITLE
Return LombScargle instance from lomb_scargle_estimator

### DIFF
--- a/src/exoplanet/estimators.py
+++ b/src/exoplanet/estimators.py
@@ -209,7 +209,7 @@ def lomb_scargle_estimator(
     # Find and fit peaks
     peaks = find_peaks(freq, power, max_peaks=max_peaks)
 
-    return dict(periodogram=(freq, power_est), peaks=peaks)
+    return dict(periodogram=(freq, power_est), peaks=peaks, model=model)
 
 
 def next_pow_two(n):

--- a/src/exoplanet/estimators.py
+++ b/src/exoplanet/estimators.py
@@ -209,7 +209,7 @@ def lomb_scargle_estimator(
     # Find and fit peaks
     peaks = find_peaks(freq, power, max_peaks=max_peaks)
 
-    return dict(periodogram=(freq, power_est), peaks=peaks, model=model)
+    return dict(periodogram=(freq, power_est), peaks=peaks, ls=model)
 
 
 def next_pow_two(n):


### PR DESCRIPTION
The `bls_estimator` returns the `BoxLeastSquares` instance (as key `'bls'`), but currently the model instance is not returned for `lomb_scargle_estimator`.