### PR TITLE
Citation update: agol19 -> agol20

### DIFF
--- a/src/exoplanet/citations.py
+++ b/src/exoplanet/citations.py
@@ -245,7 +245,7 @@ publisher={PeerJ Inc.}
 """,
     ),
     "starry": (
-        ("exoplanet:luger18", "exoplanet:agol19"),
+        ("exoplanet:luger18", "exoplanet:agol20"),
         r"""
 @article{exoplanet:luger18,
    author = {{Luger}, R. and {Agol}, E. and {Foreman-Mackey}, D. and {Fleming},
@@ -261,15 +261,19 @@ publisher={PeerJ Inc.}
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@article{exoplanet:agol19,
-       author = {{Agol}, Eric and {Luger}, Rodrigo and {Foreman-Mackey}, Daniel},
-        title = "{Analytic Planetary Transit Light Curves and Derivatives
-                  for Stars with Polynomial Limb Darkening}",
-      journal = {arXiv e-prints},
-         year = 2019,
-        month = aug,
-       eprint = {1908.03222},
-          url = {http://arxiv.org/abs/1908.03222}
+@article{exoplanet:agol20,
+    author = {{Agol}, Eric and {Luger}, Rodrigo and {Foreman-Mackey}, Daniel},
+    title = "{Analytic Planetary Transit Light Curves and Derivatives for
+    Stars with Polynomial Limb Darkening}",
+    journal = {\aj},
+     year = 2020,
+    month = mar,
+    volume = {159},
+    number = {3},
+    pages = {123},
+      doi = {10.3847/1538-3881/ab4fee},
+    adsurl = {https://ui.adsabs.harvard.edu/abs/2020AJ....159..123A},
+    adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 """,
     ),

--- a/src/exoplanet/citations.py
+++ b/src/exoplanet/citations.py
@@ -262,18 +262,18 @@ publisher={PeerJ Inc.}
 }
 
 @article{exoplanet:agol20,
-    author = {{Agol}, Eric and {Luger}, Rodrigo and {Foreman-Mackey}, Daniel},
+   author = {{Agol}, Eric and {Luger}, Rodrigo and {Foreman-Mackey}, Daniel},
     title = "{Analytic Planetary Transit Light Curves and Derivatives for
-    Stars with Polynomial Limb Darkening}",
-    journal = {\aj},
+              Stars with Polynomial Limb Darkening}",
+  journal = {\aj},
      year = 2020,
     month = mar,
-    volume = {159},
-    number = {3},
+   volume = {159},
+   number = {3},
     pages = {123},
       doi = {10.3847/1538-3881/ab4fee},
-    adsurl = {https://ui.adsabs.harvard.edu/abs/2020AJ....159..123A},
-    adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+   adsurl = {https://ui.adsabs.harvard.edu/abs/2020AJ....159..123A},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 """,
     ),


### PR DESCRIPTION
Previously, "exoplanet:agol19" pointed to the arXiv reference for
"Analytic Planetary Transit Light Curves and Derivatives for Stars with
Polynomial Limb Darkening'.

Since this paper is now in press at AJ, the reference should be updated.
This will help people who copy-paste the citation into their papers, so
that they don't need to fix the reference during the proofing stages ;-)

The only relevant test from what I can tell is `tests/citations_test.py`,
which passed.