### PR TITLE
Update rebound/reboundx citations

### DIFF
--- a/src/exoplanet/citations.py
+++ b/src/exoplanet/citations.py
@@ -331,8 +331,46 @@ publisher={PeerJ Inc.}
     "rebound": (
         ("exoplanet:rebound",),
         r"""
-FIXME!!
+@ARTICLE{rebound,
+       author = {{Rein}, H. and {Liu}, S. -F.},
+        title = "{REBOUND: an open-source multi-purpose N-body code for collisional dynamics}",
+      journal = {\aap},
+     keywords = {methods: numerical, planets and satellites: rings, protoplanetary disks, Astrophysics - Earth and Planetary Astrophysics, Astrophysics - Instrumentation and Methods for Astrophysics, Mathematics - Dynamical Systems, Physics - Computational Physics},
+         year = 2012,
+        month = jan,
+       volume = {537},
+          eid = {A128},
+        pages = {A128},
+          doi = {10.1051/0004-6361/201118085},
+archivePrefix = {arXiv},
+       eprint = {1110.4876},
+ primaryClass = {astro-ph.EP},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2012A&A...537A.128R},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
 """,
+    ),
+    "reboundias15": (
+        ("exoplanet:reboundias15",),
+        r"""
+@ARTICLE{reboundias15,
+       author = {{Rein}, Hanno and {Spiegel}, David S.},
+        title = "{IAS15: a fast, adaptive, high-order integrator for gravitational dynamics, accurate to machine precision over a billion orbits}",
+      journal = {\mnras},
+     keywords = {gravitation, methods: numerical, planets and satellites: dynamical evolution and stability, Astrophysics - Earth and Planetary Astrophysics, Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Solar and Stellar Astrophysics, Mathematics - Numerical Analysis},
+         year = 2015,
+        month = jan,
+       volume = {446},
+       number = {2},
+        pages = {1424-1437},
+          doi = {10.1093/mnras/stu2164},
+archivePrefix = {arXiv},
+       eprint = {1409.4779},
+ primaryClass = {astro-ph.EP},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2015MNRAS.446.1424R},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+"""
     ),
     "vaneylen19": (
         ("exoplanet:vaneylen19",),

--- a/src/exoplanet/citations.py
+++ b/src/exoplanet/citations.py
@@ -370,7 +370,7 @@ archivePrefix = {arXiv},
        adsurl = {https://ui.adsabs.harvard.edu/abs/2015MNRAS.446.1424R},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
-"""
+""",
     ),
     "vaneylen19": (
         ("exoplanet:vaneylen19",),

--- a/src/exoplanet/orbits/rebound.py
+++ b/src/exoplanet/orbits/rebound.py
@@ -40,7 +40,8 @@ class ReboundOrbit(KeplerianOrbit):
 
     """
 
-    __citations__ = ("astropy", "rebound")
+    __citations__ = ("astropy", "rebound", "reboundias15,"
+                                           "reboundx")
 
     def __init__(self, *args, **kwargs):
         rebound_args = dict(

--- a/src/exoplanet/orbits/rebound.py
+++ b/src/exoplanet/orbits/rebound.py
@@ -40,8 +40,7 @@ class ReboundOrbit(KeplerianOrbit):
 
     """
 
-    __citations__ = ("astropy", "rebound", "reboundias15,"
-                                           "reboundx")
+    __citations__ = ("astropy", "rebound", "reboundias15," "reboundx")
 
     def __init__(self, *args, **kwargs):
         rebound_args = dict(


### PR DESCRIPTION
Fixes #134.

I've added a few BibTeX entries to `citations.py` and referenced those entries in `rebound.py`. 

I was hoping to use something like `sim.cite` to gather the correct `rebound`-related citations (more elegant from the perspective of the `rebound` codebase), but I don't think that it fits in cleanly with the `exoplanet` API, as the citations would only be aggregated *after* a simulation was initialized — as of now, I believe, models citations can be referenced without them being start up. I'd be happy to change this, though!

I've only included the `reboundx` citation relevant to general relativistic forces. There are a bunch of other cool forces that are implemented in `reboundx` (mass loss, tides) that involve other citations. Yet another set of effects (radiation effects, gravitational harmonics, custom integration steppers, central force parameterization) are included in this citation, in case they'd be implemented at any point.