### PR TITLE
Added a very basic reflected light approximation to SecondaryEclipseLightCurve WIP

### DIFF
--- a/src/exoplanet/light_curves/secondary_eclipse.py
+++ b/src/exoplanet/light_curves/secondary_eclipse.py
@@ -4,6 +4,8 @@ __all__ = ["SecondaryEclipseLightCurve"]
 
 from ..utils import as_tensor_variable
 from .limb_dark import LimbDarkLightCurve
+import numpy as np
+from theano.tensor import cos, arcsin
 
 
 class SecondaryEclipseLightCurve:
@@ -38,6 +40,8 @@ class SecondaryEclipseLightCurve:
         order=0,
         use_in_transit=None,
         light_delay=False,
+        reflected=False,
+        lag=0
     ):
         r = as_tensor_variable(r)
         orbit2 = orbit._flip(r)
@@ -64,5 +68,10 @@ class SecondaryEclipseLightCurve:
 
         k = r / orbit.r_star
         flux_ratio = self.surface_brightness_ratio * k ** 2
+        if reflected:
+            phase = (t - orbit2.t0)/orbit2.period % 1
+            phase_curve = cos(2 * phase * np.pi + lag)[:, None]
+            lc_2_w_phase_curve = (lc2) + phase_curve * 0**(-lc2)
+            return (lc1 + lc_2_w_phase_curve * flux_ratio + flux_ratio)/(1 + flux_ratio)
 
         return (lc1 + flux_ratio * lc2) / (1 + flux_ratio)

--- a/src/exoplanet/light_curves/secondary_eclipse.py
+++ b/src/exoplanet/light_curves/secondary_eclipse.py
@@ -5,7 +5,7 @@ __all__ = ["SecondaryEclipseLightCurve"]
 from ..utils import as_tensor_variable
 from .limb_dark import LimbDarkLightCurve
 import numpy as np
-from theano.tensor import cos, arcsin
+from theano.tensor import cos
 
 
 class SecondaryEclipseLightCurve:
@@ -71,7 +71,7 @@ class SecondaryEclipseLightCurve:
         if reflected:
             phase = (t - orbit2.t0)/orbit2.period % 1
             phase_curve = cos(2 * phase * np.pi + lag)[:, None]
-            lc_2_w_phase_curve = (lc2) + phase_curve * 0**(-lc2)
-            return (lc1 + lc_2_w_phase_curve * flux_ratio + flux_ratio)/(1 + flux_ratio)
+            lc2_w_phase_curve = (lc2) + phase_curve * 0**(-lc2)
+            return (lc1 + lc2_w_phase_curve * flux_ratio + flux_ratio)/(1 + flux_ratio)
 
         return (lc1 + flux_ratio * lc2) / (1 + flux_ratio)


### PR DESCRIPTION
I saw there is a WIP to add `SecondaryEclipseLightCurve` to `exoplanet`, but that it doesn't include reflected light. I added a silly approximation to quickly add in a reflected light phase curve (just a cosine function), that has a `lag` keyword to shift the "hotspot" on the planet. This is a silly approximation because it doesn't work when there is a large lag, and it's not calculating the ingress/egress correctly.

I assume part of the WIP is to include `starry` reflected light. But just for now, because I wanted to use `SecondaryEclipseLightCurve`, I made this edit, and I thought I'd post it here in case anyone was interested in seeing. Not looking for this to be merged, but if anyone had comments about how to contribute to `exoplanet` better, I'd read them!

Here's an example use

```python
import matplotlib.pyplot as plt
import exoplanet as xo
import numpy as np
t = np.arange(0, 2, 0.001)
period = 0.5

orbit = xo.orbits.KeplerianOrbit(period=period, r_star=1, m_star=1)
sec = xo.SecondaryEclipseLightCurve([0.2, 0.25], [0], 0.01).get_light_curve(orbit=orbit, r=0.1, t=t, reflected=True, lag=0.2)
plt.plot(sec.eval()[:, 0])
``` 
![image](https://user-images.githubusercontent.com/14965634/106527876-d10e8e80-649c-11eb-84ca-4e77b800eea9.png)
