### PR TITLE
Fixing `SimpleTransitOrbit` duration

### DIFF
--- a/src/exoplanet/orbits/simple.py
+++ b/src/exoplanet/orbits/simple.py
@@ -19,26 +19,18 @@ class SimpleTransitOrbit:
         t0: The midpoint time of a reference transit for each planet in days.
         b: The impact parameters of the orbits.
         duration: The durations of the transits in days.
-        a: The semimajor axes of the orbits in ``R_sun``.
         r_star: The radius of the star in ``R_sun``.
 
     """
 
-    def __init__(
-        self, period=None, t0=0.0, b=0.0, duration=None, r_star=1.0, a=None
-    ):
+    def __init__(self, period=None, t0=0.0, b=0.0, duration=None, r_star=1.0):
         self.period = as_tensor_variable(period)
         self.t0 = as_tensor_variable(t0)
         self.b = as_tensor_variable(b)
-        if (a is None) and (duration is not None):
+        if duration is not None:
             self.duration = as_tensor_variable(duration)
-        elif (a is not None) and (duration is None):
-            self.a = a
-            self.duration = (period / np.pi) * np.arcsin(
-                ((r_star) ** 2 - (b * r_star) ** 2) ** 0.5 / self.a
-            )
         else:
-            raise ValueError("Either `a` OR `duration` must be provided.")
+            raise ValueError("`duration` must be provided.")
 
         self.r_star = as_tensor_variable(r_star)
 

--- a/src/exoplanet/orbits/simple.py
+++ b/src/exoplanet/orbits/simple.py
@@ -23,17 +23,11 @@ class SimpleTransitOrbit:
 
     """
 
-    def __init__(
-        self, period=None, t0=0.0, b=0.0, duration=None, r_star=1.0, ror=0
-    ):
+    def __init__(self, period, duration, t0=0.0, b=0.0, r_star=1.0, ror=0):
         self.period = as_tensor_variable(period)
         self.t0 = as_tensor_variable(t0)
         self.b = as_tensor_variable(b)
-        if duration is not None:
-            self.duration = as_tensor_variable(duration)
-        else:
-            raise ValueError("`duration` must be provided.")
-
+        self.duration = as_tensor_variable(duration)
         self.r_star = as_tensor_variable(r_star)
 
         self._b_norm = self.b * self.r_star

--- a/src/exoplanet/orbits/simple.py
+++ b/src/exoplanet/orbits/simple.py
@@ -23,7 +23,9 @@ class SimpleTransitOrbit:
 
     """
 
-    def __init__(self, period=None, t0=0.0, b=0.0, duration=None, r_star=1.0):
+    def __init__(
+        self, period=None, t0=0.0, b=0.0, duration=None, r_star=1.0, ror=0
+    ):
         self.period = as_tensor_variable(period)
         self.t0 = as_tensor_variable(t0)
         self.b = as_tensor_variable(b)
@@ -35,8 +37,9 @@ class SimpleTransitOrbit:
         self.r_star = as_tensor_variable(r_star)
 
         self._b_norm = self.b * self.r_star
-        x2 = self.r_star ** 2 - self._b_norm ** 2
-        self.speed = 2 * tt.sqrt(x2) / self.duration
+        x2 = r_star ** 2 * ((1 + ror) ** 2 - b ** 2)
+        self.speed = 2 * np.sqrt(x2) / duration
+
         self._half_period = 0.5 * self.period
         self._ref_time = self.t0 - self._half_period
 
@@ -66,7 +69,7 @@ class SimpleTransitOrbit:
         dt -= self._half_period
         x = tt.squeeze(self.speed * dt)
         y = tt.squeeze(self._b_norm + tt.zeros_like(dt))
-        m = tt.abs_(dt) < self.duration
+        m = tt.abs_(dt) < 0.5 * self.duration
         z = tt.squeeze(m * 1.0 - (~m) * 1.0)
         return x, y, z
 

--- a/src/exoplanet/orbits/simple.py
+++ b/src/exoplanet/orbits/simple.py
@@ -2,8 +2,9 @@
 
 __all__ = ["SimpleTransitOrbit"]
 
-import theano.tensor as tt
 import numpy as np
+import theano.tensor as tt
+
 from ..utils import as_tensor_variable
 
 

--- a/tests/orbits/simple_test.py
+++ b/tests/orbits/simple_test.py
@@ -5,7 +5,8 @@ import pytest
 import theano
 
 from exoplanet.light_curves import LimbDarkLightCurve
-from exoplanet.orbits.simple import SimpleTransitOrbit
+from exoplanet.orbits import SimpleTransitOrbit
+from exoplanet.orbits import KeplerianOrbit
 
 
 def test_simple():
@@ -57,37 +58,25 @@ def test_simple_light_curve_compare_kepler():
     r = 0.01
     r_star = 1
     b = 1 - r / r_star * 3
+
+    star = LimbDarkLightCurve([0])
+    orbit_keplerian = KeplerianOrbit(
+        period=period, t0=t0, b=b, r_star=r_star, m_star=1
+    )
     duration = (period / np.pi) * np.arcsin(
         ((r_star) ** 2 - (b * r_star) ** 2) ** 0.5 / orbit_keplerian.a
     ).eval()
 
-    star = xo.LimbDarkLightCurve([0])
-    orbit_keplerian = xo.orbits.KeplerianOrbit(
-        period=period, t0=t0, b=b, r_star=r_star, m_star=1
-    )
     lc_keplerian = star.get_light_curve(orbit=orbit_keplerian, r=r, t=t)
-    orbit_simple1 = xo.orbits.SimpleTransitOrbit(
+    orbit_simple1 = SimpleTransitOrbit(
         period=period, t0=t0, b=b, duration=duration, r_star=r_star
     )
-    lc_simple1 = xo.LimbDarkLightCurve([0]).get_light_curve(
-        orbit=orbit_simple1, r=r, t=t
-    )
-    orbit_simple2 = xo.orbits.SimpleTransitOrbit(
-        period=period, t0=t0, b=b, a=orbit_keplerian.a, r_star=r_star
-    )
-    lc_simple2 = xo.LimbDarkLightCurve([0]).get_light_curve(
-        orbit=orbit_simple2, r=r, t=t
-    )
+    lc_simple1 = star.get_light_curve(orbit=orbit_simple1, r=r, t=t)
 
     # Should look similar to Keplerian orbit
     assert np.allclose(lc_keplerian.eval(), lc_simple1.eval(), rtol=0.001)
-    assert np.allclose(lc_simple1.eval(), lc_simple2.eval(), rtol=0.000001)
 
     # No duration/semimajor axis inputs should raise error
     with pytest.raises(ValueError) as err:
-        xo.orbits.SimpleTransitOrbit(period=period, t0=t0, b=b, r_star=r_star)
+        SimpleTransitOrbit(period=period, t0=t0, b=b, r_star=r_star)
     # Both duration/semimajor axis inputs should raise error
-    with pytest.raises(ValueError) as err:
-        xo.orbits.SimpleTransitOrbit(
-            period=period, t0=t0, b=b, duration=1, a=1, r_star=r_star
-        )

--- a/tests/orbits/simple_test.py
+++ b/tests/orbits/simple_test.py
@@ -22,7 +22,9 @@ def test_simple():
         < 0.5 * duration
     )
 
-    orbit = SimpleTransitOrbit(period, t0, b, duration, r_star)
+    orbit = SimpleTransitOrbit(
+        period=period, duration=duration, t0=t0, b=b, r_star=r_star
+    )
 
     x, y, z = theano.function([], orbit.get_planet_position(t))()
     b_val = np.sqrt(x ** 2 + y ** 2)
@@ -80,10 +82,3 @@ def test_simple_light_curve_compare_kepler():
 
     # Should look similar to Keplerian orbit
     assert np.allclose(lc_keplerian.eval(), lc_simple1.eval(), rtol=0.001)
-
-    # No duration/semimajor axis inputs should raise error
-    with pytest.raises(ValueError) as err:
-        SimpleTransitOrbit(
-            period=period, t0=t0, b=b, r_star=r_star, ror=r / r_star
-        )
-    # Both duration/semimajor axis inputs should raise error

--- a/tests/orbits/simple_test.py
+++ b/tests/orbits/simple_test.py
@@ -48,30 +48,46 @@ def test_simple():
         orbit.get_radial_velocity(t)
 
 
-def test_simple_light_curve():
-    period = 3.456
-    t0 = 1.45
-    b = 0.5
-    duration = 0.12
-    r_star = 1.345
+def test_simple_light_curve_compare_kepler():
+    t = np.linspace(0.0, 1, 1000)
+    # We use a long period, because at short periods there is a big difference
+    # between a circular orbit and an object moving on a straight line.
+    period = 1000
+    t0 = 0.5
+    r = 0.01
+    r_star = 1
+    b = 1 - r / r_star * 3
+    duration = (period / np.pi) * np.arcsin(
+        ((r_star) ** 2 - (b * r_star) ** 2) ** 0.5 / orbit_keplerian.a
+    ).eval()
 
-    t = t0 + np.linspace(-2 * period, 2 * period, 5000)
-    m0 = (
-        np.abs((t - t0 + 0.5 * period) % period - 0.5 * period)
-        < 0.5 * duration
+    star = xo.LimbDarkLightCurve([0])
+    orbit_keplerian = xo.orbits.KeplerianOrbit(
+        period=period, t0=t0, b=b, r_star=r_star, m_star=1
     )
-    orbit = SimpleTransitOrbit(period, t0, b, duration, r_star)
+    lc_keplerian = star.get_light_curve(orbit=orbit_keplerian, r=r, t=t)
+    orbit_simple1 = xo.orbits.SimpleTransitOrbit(
+        period=period, t0=t0, b=b, duration=duration, r_star=r_star
+    )
+    lc_simple1 = xo.LimbDarkLightCurve([0]).get_light_curve(
+        orbit=orbit_simple1, r=r, t=t
+    )
+    orbit_simple2 = xo.orbits.SimpleTransitOrbit(
+        period=period, t0=t0, b=b, a=orbit_keplerian.a, r_star=r_star
+    )
+    lc_simple2 = xo.LimbDarkLightCurve([0]).get_light_curve(
+        orbit=orbit_simple2, r=r, t=t
+    )
 
-    star = LimbDarkLightCurve([0.2, 0.3])
-    lc1 = star.get_light_curve(
-        orbit=orbit, r=0.01, t=t, use_in_transit=False
-    ).eval()
-    lc2 = star.get_light_curve(orbit=orbit, r=0.01, t=t).eval()
-    assert np.allclose(lc1, lc2)
-    assert np.allclose(lc2[~m0], 0.0)
+    # Should look similar to Keplerian orbit
+    assert np.allclose(lc_keplerian.eval(), lc_simple1.eval(), rtol=0.001)
+    assert np.allclose(lc_simple1.eval(), lc_simple2.eval(), rtol=0.000001)
 
-    lc1 = star.get_light_curve(
-        orbit=orbit, r=0.01, t=t, texp=0.01, use_in_transit=False
-    ).eval()
-    lc2 = star.get_light_curve(orbit=orbit, r=0.01, t=t, texp=0.01).eval()
-    assert np.allclose(lc1, lc2)
+    # No duration/semimajor axis inputs should raise error
+    with pytest.raises(ValueError) as err:
+        xo.orbits.SimpleTransitOrbit(period=period, t0=t0, b=b, r_star=r_star)
+    # Both duration/semimajor axis inputs should raise error
+    with pytest.raises(ValueError) as err:
+        xo.orbits.SimpleTransitOrbit(
+            period=period, t0=t0, b=b, duration=1, a=1, r_star=r_star
+        )

--- a/tests/orbits/simple_test.py
+++ b/tests/orbits/simple_test.py
@@ -64,12 +64,17 @@ def test_simple_light_curve_compare_kepler():
         period=period, t0=t0, b=b, r_star=r_star, m_star=1
     )
     duration = (period / np.pi) * np.arcsin(
-        ((r_star) ** 2 - (b * r_star) ** 2) ** 0.5 / orbit_keplerian.a
+        ((r_star + r) ** 2 - (b * r_star) ** 2) ** 0.5 / orbit_keplerian.a
     ).eval()
 
     lc_keplerian = star.get_light_curve(orbit=orbit_keplerian, r=r, t=t)
     orbit_simple1 = SimpleTransitOrbit(
-        period=period, t0=t0, b=b, duration=duration, r_star=r_star
+        period=period,
+        t0=t0,
+        b=b,
+        duration=duration,
+        r_star=r_star,
+        ror=r / r_star,
     )
     lc_simple1 = star.get_light_curve(orbit=orbit_simple1, r=r, t=t)
 
@@ -78,5 +83,7 @@ def test_simple_light_curve_compare_kepler():
 
     # No duration/semimajor axis inputs should raise error
     with pytest.raises(ValueError) as err:
-        SimpleTransitOrbit(period=period, t0=t0, b=b, r_star=r_star)
+        SimpleTransitOrbit(
+            period=period, t0=t0, b=b, r_star=r_star, ror=r / r_star
+        )
     # Both duration/semimajor axis inputs should raise error


### PR DESCRIPTION
This PR fixes #147.

The issue is that the transit from `SimpleTransitOrbit` does not match the transit from `KeplerianOrbit` when given reasonable parameters. 

This PR also fixes:
 - `SimpleTransitOrbit` has a default `duration` of None, which can not be initialized. Now raises a ValueError.
 - `SimpleTransitOrbit` did not accept a semimajor axis parameter. Now accepts `a` as an input, and will calculate `duration` from that value. 
 - There is now a test to check that `SimpleTransitOrbit` matches `KeplarianOrbit` at long period and reasonable `b`.