### PR TITLE
Add get_star_relative_angles() function and create tests for get relative angle functions

### DIFF
--- a/src/exoplanet/orbits/keplerian.py
+++ b/src/exoplanet/orbits/keplerian.py
@@ -566,6 +566,34 @@ class KeplerianOrbit:
         theta = tt.squeeze(tt.arctan2(Y, X))  # radians between [-pi, pi]
 
         return (rho, theta)
+    
+    
+    
+    def get_star_relative_angles(self, t, parallax=None, light_delay=False):
+    """The stars' relative position to the star in the sky plane, in
+    separation, position angle coordinates.
+    .. note:: This treats each planet independently and does not take the
+        other planets into account when computing the position of the
+        star. This is fine as long as the planet masses are small.
+    Args:
+        t: The times where the position should be evaluated.
+        light_delay: account for the light travel time delay? Default is
+            False.
+    Returns:
+        The separation (arcseconds) and position angle (radians,
+        measured east of north) of the planet relative to the star.
+    """
+    X, Y, Z = self._get_star_position(
+        -self.a, t, parallax, light_delay=light_delay
+    )
+
+    # calculate rho and theta
+    rho = tt.squeeze(tt.sqrt(X ** 2 + Y ** 2))  # arcsec
+    theta = tt.squeeze(tt.arctan2(Y, X))  # radians between [-pi, pi]
+
+    return (rho, theta)
+
+
 
     def _get_velocity(self, m, t):
         """Get the velocity vector of a body in the observer frame"""

--- a/tests/orbits/keplerian_test.py
+++ b/tests/orbits/keplerian_test.py
@@ -703,3 +703,78 @@ def test_jacobians():
         orbit.jacobians["b"]["cos_incl"].eval(),
         theano.grad(orbit.cos_incl, bv).eval(),
     )
+    
+    
+def test_relative_angles():
+    #test seperation and position angle with Earth and Sun
+    p_earth=365.256
+    t = np.linspace(0, 1000, 1000)
+    m_earth = 1.*3.00273e-6 #units m_sun
+    orbit_earth = xo.orbits.KeplerianOrbit(
+        m_star=1.,
+        r_star=1.,
+        t0=0.5,
+        period=p_earth,
+        ecc=0.0167,
+        omega=np.radians(102.9),
+        Omega=np.radians(0.0),
+        incl=np.radians(45.0),
+        m_planet=m_earth,
+    )
+
+
+    rho_star_earth, theta_star_earth = theano.function([], orbit_earth._get_star_relative_angles(t, parallax=0.1))()
+    rho_earth, theta_earth = theano.function([], orbit_earth._get_relative_angles(t, parallax=0.1))()
+
+    rho_star_earth_diff = np.max(rho_star_earth) - np.min(rho_star_earth)
+    rho_earth_diff = np.max(rho_earth)- np.min(rho_earth)
+
+
+    #make sure amplitude of separation is correct for star and planet motion
+    assert np.isclose(rho_earth_diff, 3.0813126e-02)
+    assert np.isclose(rho_star_earth_diff, 9.2523221e-08)
+
+
+    #make sure planet and star position angle closely mirrors each other
+    assert np.allclose(theta_earth[:int(p_earth/2)], theta_star_earth[int(p_earth/2):int(p_earth)-1], atol=0.2)
+
+
+
+    #test seperation with Jupiter and Sun
+    p_jup=4327.631
+    t = np.linspace(0, 10000, 10000)
+    m_jup = 317.83*3.00273e-6 #units m_sun
+    orbit_jup = KeplerianOrbit(
+        m_star=1.,
+        r_star=1.,
+        t0=2000,
+        period=p_jup,
+        ecc=0.0484,
+        omega=np.radians(274.3) - 2*np.pi,
+        Omega=np.radians(100.4),
+        incl=np.radians(45.0),
+        m_planet=m_jup,
+    )
+
+
+    rho_star_jup, theta_star_jup = theano.function([], orbit_jup._get_star_relative_angles(t, parallax=0.1))()
+    rho_jup, theta_jup = theano.function([], orbit_jup._get_relative_angles(t, parallax=0.1))()
+
+    rho_star_earth_diff = np.max(rho_star_jup) - np.min(rho_star_jup)
+    rho_earth_diff = np.max(rho_jup)- np.min(rho_jup)
+
+    
+    #make sure amplitude of separation is correct for star and planet motion
+    assert np.isclose(rho_jup_diff, 1.7190731e-01)
+    assert np.isclose(rho_star_jup_diff, 1.6390463e-04)
+
+
+    #make sure planet and star position angle closely mirrors each other
+    assert np.allclose(theta_jup[:int(p_jup/2)], theta_star_jup[int(p_jup/2):int(p_jup)-1], atol=0.2)
+
+
+
+    
+
+
+

--- a/tests/orbits/keplerian_test.py
+++ b/tests/orbits/keplerian_test.py
@@ -706,7 +706,8 @@ def test_jacobians():
     
     
 def test_relative_angles():
-    #test seperation and position angle with Earth and Sun
+    
+    #test separation and position angle with Earth and Sun
     p_earth=365.256
     t = np.linspace(0, 1000, 1000)
     m_earth = 1.*3.00273e-6 #units m_sun
@@ -739,8 +740,9 @@ def test_relative_angles():
     assert np.allclose(theta_earth[:int(p_earth/2)], theta_star_earth[int(p_earth/2):int(p_earth)-1], atol=0.2)
 
 
-
-    #test seperation with Jupiter and Sun
+    ########################################
+    ########################################
+    #test separation with Jupiter and Sun
     p_jup=4327.631
     t = np.linspace(0, 10000, 10000)
     m_jup = 317.83*3.00273e-6 #units m_sun

--- a/tests/orbits/keplerian_test.py
+++ b/tests/orbits/keplerian_test.py
@@ -742,7 +742,7 @@ def test_relative_angles():
 
     ########################################
     ########################################
-    #test separation with Jupiter and Sun
+    #test separation and position angle with Jupiter and Sun
     p_jup=4327.631
     t = np.linspace(0, 10000, 10000)
     m_jup = 317.83*3.00273e-6 #units m_sun


### PR DESCRIPTION
I wrote code and tests and we discussed for the get_star_relative_angles() function. I couldn't find any existing tests for the get_relative_angles() function for the relative angles of the planet, so I wrote tests for that existing function as well and included it in the same test function.

One other thing I noticed is that in the get_relative_angles() function, it currently calls the "get_position()" function rather than "get_planet_position()" function. I don't think that this would make any changes if I am understanding the code correctly, but it may be better to switch this for clarity. Let me know if you would like me to submit another pull request with this change.

Hopefully this works! Thanks!