### PR TITLE
fix link to citation page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -91,4 +91,4 @@ The source code is made available under the terms of the MIT license.
 
 If you make use of this code, please cite this package and its dependencies. You
 can find more information about how and what to cite in the `citation
-<tutorials/citation.ipynb>`_ documentation.
+<tutorials/citation.md>`_ documentation.


### PR DESCRIPTION
Noticed that the citation link in the [license+attribution section](https://github.com/exoplanet-dev/exoplanet/blob/main/docs/index.rst#license--attribution) points to a non-existent page:
>  https://docs.exoplanet.codes/en/latest/tutorials/citation.ipynb

I think this is the intended page is the  `tutorials/citation.md`? 